### PR TITLE
Fix build by pinning huggingface_hub version

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,8 @@ RUN pip install --no-cache-dir --upgrade pip && \
         insightface==0.7.3 \
         diffusers==0.28.2 \
         transformers==4.41.2 \
-        accelerate==0.30.1
+        accelerate==0.30.1 \
+        huggingface-hub==0.19.4
 
 # 백엔드 소스 코드 복사
 COPY . .

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,8 @@ fastapi
 uvicorn
 python-multipart
 opencv-python-headless
+insightface==0.7.3
+diffusers==0.28.2
+transformers==4.41.2
+accelerate==0.30.1
+huggingface-hub==0.19.4


### PR DESCRIPTION
## Summary
- pin huggingface-hub version so diffusers can import cached_download
- update backend requirements for consistency

## Testing
- `python -m py_compile backend/main.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a43c325070832087f6c05b72d6dcda